### PR TITLE
Potential fix for code scanning alert no. 25: Server-side request forgery

### DIFF
--- a/.github/actions/tool-setup/packagist-proxy.mjs
+++ b/.github/actions/tool-setup/packagist-proxy.mjs
@@ -72,13 +72,23 @@ server.on( 'request', ( req, res ) => {
 		}
 	}
 
+	// Validate and sanitize req.url
+	const allowedPaths = ['/packages.json', '/p2/'];
+	const sanitizedUrl = allowedPaths.find(path => req.url.startsWith(path));
+	if (!sanitizedUrl) {
+		console.log(`!![${ reqid }] Invalid request path: ${ req.url }`);
+		res.writeHead(400, 'Bad Request');
+		res.end('Invalid request path');
+		return;
+	}
+
 	// Make remote request.
-	const upstreamUrl = upstreamHost + req.url.replace( /^\//, '' );
-	console.log( `!![${ reqid }] Proxying to ${ upstreamUrl }` );
-	const upstreamReq = https.request( upstreamUrl, {
+	const upstreamUrl = upstreamHost + sanitizedUrl.replace(/^\//, '');
+	console.log(`!![${ reqid }] Proxying to ${ upstreamUrl }`);
+	const upstreamReq = https.request(upstreamUrl, {
 		method: req.method,
 		headers,
-	} );
+	});
 
 	let sentResponse = false;
 	upstreamReq.on( 'response', upstreamRes => {


### PR DESCRIPTION
Potential fix for [https://github.com/slowedcodinganai/jetpack/security/code-scanning/25](https://github.com/slowedcodinganai/jetpack/security/code-scanning/25)

To fix the problem, we need to ensure that the user input in `req.url` does not lead to an SSRF vulnerability. The best way to do this is to validate and sanitize the `req.url` before using it to construct the `upstreamUrl`. We can achieve this by ensuring that the `req.url` only contains allowed paths and does not include any malicious input.

We will implement a whitelist of allowed paths and check if the `req.url` matches any of these paths. If it does, we will proceed with the request; otherwise, we will return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
